### PR TITLE
Make compatible with Qt6 and fix deprecations

### DIFF
--- a/QSingleInstance/clientinstance.cpp
+++ b/QSingleInstance/clientinstance.cpp
@@ -11,8 +11,12 @@ ClientInstance::ClientInstance(QLocalSocket *socket, QSingleInstancePrivate *par
 	stream(socket)
 {
 	connect(socket, &QLocalSocket::readyRead, this, &ClientInstance::newData);
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
 	connect(socket, QOverload<QLocalSocket::LocalSocketError>::of(&QLocalSocket::error),
 			this, &ClientInstance::socketError);
+#else
+	connect(socket, &QLocalSocket::errorOccurred, this, &ClientInstance::socketError);
+#endif
 	connect(socket, &QLocalSocket::disconnected, this, &ClientInstance::deleteLater);
 }
 

--- a/QSingleInstance/qsingleinstance.cpp
+++ b/QSingleInstance/qsingleinstance.cpp
@@ -143,7 +143,12 @@ bool QSingleInstance::resetInstanceID()
 	d->fullId.truncate(8);
 	d->fullId.prepend(QStringLiteral("qsingleinstance-"));
 	QByteArray hashBase = (QCoreApplication::organizationName() + QLatin1Char('_') + QCoreApplication::applicationName()).toUtf8();
-	d->fullId += QLatin1Char('-') + QString::number(qChecksum(hashBase.data(), hashBase.size()), 16);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+	quint16 hashValue = qChecksum(hashBase.data(), hashBase.size());
+#else
+	quint16 hashValue = qChecksum(hashBase);
+#endif
+	d->fullId += QLatin1Char('-') + QString::number(hashValue, 16);
 
 	if(!d->global) {
 		d->fullId += QLatin1Char('-');

--- a/QSingleInstance/qsingleinstance_p.cpp
+++ b/QSingleInstance/qsingleinstance_p.cpp
@@ -118,8 +118,13 @@ void QSingleInstancePrivate::sendArgs()
 			this, &QSingleInstancePrivate::clientConnected, Qt::QueuedConnection);
 	connect(client, &QLocalSocket::readyRead,
 			this, &QSingleInstancePrivate::sendResultReady, Qt::QueuedConnection);
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
 	connect(client, SIGNAL(error(QLocalSocket::LocalSocketError)),
 			this, SLOT(clientError(QLocalSocket::LocalSocketError)));
+#else
+	connect(client, SIGNAL(errorOccurred(QLocalSocket::LocalSocketError)),
+			this, SLOT(clientError(QLocalSocket::LocalSocketError)));
+#endif
 
 	client->connectToServer(socketFile(), QIODevice::ReadWrite);
 


### PR DESCRIPTION
Hi, the signal `QLocalSocket::error` is deprecated in Qt 5.15.0 and removed in Qt 6.
Also the `QByteArrayView` overload of `qChecksum` should be used in Qt 6.

