### PR TITLE
Add header <QSingleInstance>

### DIFF
--- a/QSingleInstance/QSingleInstance
+++ b/QSingleInstance/QSingleInstance
@@ -1,0 +1,1 @@
+#include "qsingleinstance.h"


### PR DESCRIPTION
Only for consistency of naming conventions.
There exists a similar one in `QCtrlSignals`.